### PR TITLE
Julia 1.0 compat

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.0'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.6.0"
 [deps]
 
 [compat]
-julia = "1.3"
+julia = "1"
 
 [extras]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/src/ExproniconLite.jl
+++ b/src/ExproniconLite.jl
@@ -1,5 +1,12 @@
 module ExproniconLite
 export NoDefault, JLExpr, JLFor, JLIfElse, JLFunction, JLField, JLKwField, JLStruct, JLKwStruct, @expr, @test_expr, compare_expr, compare_vars, AnalysisError, is_function, is_kw_function, is_struct, is_ifelse, is_for, is_field, is_field_default, split_function, split_function_head, split_struct, split_struct_name, split_ifelse, annotations, uninferrable_typevars, has_symbol, is_literal, has_kwfn_constructor, has_plain_constructor, no_default, prettify, rm_lineinfo, flatten_blocks, name_only, rm_annotations, rm_single_block, rm_nothing, replace_symbol, subtitute, eval_interp, eval_literal, codegen_ast, codegen_ast_kwfn, codegen_ast_kwfn_plain, codegen_ast_kwfn_infer, codegen_ast_struct, codegen_ast_struct_head, codegen_ast_struct_body, construct_method_plain, construct_method_inferable, struct_name_plain, struct_name_without_inferable, xtuple, xnamedtuple, xcall, xpush, xfirst, xlast, xprint, xprintln, xmap, xmapreduce, xiterate, print_expr, sprint_expr
+
+if VERSION < v"1.3"
+    macro var_str(x)
+        Symbol(x)
+    end
+end
+
 include("types.jl")
 #= /home/roger/code/julia/Expronicon/src/expand.jl:99 =# @static if !(isdefined(#= /home/roger/code/julia/Expronicon/src/expand.jl:99 =# @__MODULE__(), :include_generated))
         function include_generated(m::Module, path::String)


### PR DESCRIPTION
I want to use Configurations.jl in Pluto, but we support Julia 1.0 and up, the compatibility of Configurations is bound to `>=1.3`. It seems like this package was the limiting factor.